### PR TITLE
*: unify Dockerfile naming schema across all monitoring team repos

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,4 @@
-# Note: This file is NOT used by openshift build system.
-# TODO(paulfantom): Replace this file with upstream one on next sync.
+# Dockerfile used by OSBS and by prow CI.
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/jimmidyson/configmap-reload
 COPY . .


### PR DESCRIPTION
By moving our Dockerfile to separate file we should have a simpler repository synchronization in the future.

Part of MON-702