### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -9,7 +9,8 @@ FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 LABEL io.k8s.display-name="OpenShift ConfigMap Reload" \
       io.k8s.description="This is a component reloads another process if a configured configmap volume is remounted." \
       io.openshift.tags="kubernetes" \
-      maintainer="Frederic Branczyk <fbranczy@redhat.com>"
+      summary="This is a component reloads another process if a configured configmap volume is remounted." \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
 
 ARG FROM_DIRECTORY=/go/src/github.com/jimmidyson/configmap-reload
 COPY --from=builder ${FROM_DIRECTORY}/out/configmap-reload  /usr/bin/configmap-reload


### PR DESCRIPTION
- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value

/cc @openshift/openshift-team-monitoring