### PR TITLE
Updating configmap-reload builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,11 +1,11 @@
 # Dockerfile used by OSBS and by prow CI.
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/jimmidyson/configmap-reload
 COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN make out/configmap-reload
 
-FROM  registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 LABEL io.k8s.display-name="OpenShift ConfigMap Reload" \
       io.k8s.description="This is a component reloads another process if a configured configmap volume is remounted." \
       io.openshift.tags="kubernetes" \


### PR DESCRIPTION
Updating configmap-reload builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/configmap-reload.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.