### PR TITLE
Set CGO_ENABLED=1 and remove `extldflags -static`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ job_defaults: &job_defaults
   - image: golang:1.17
 
   environment: &env_defaults
-  - CGO_ENABLED: "0"
+  - CGO_ENABLED: "1"
   - GO111MODULE: "on"
 
 docker_job_defaults: &docker_job_defaults

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SHELL := /bin/bash -euo pipefail
 
 # Use the native vendor/ dependency system
 export GO111MODULE := on
-export CGO_ENABLED := 0
+export CGO_ENABLED := 1
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -25,7 +25,7 @@ REPOPATH ?= $(ORG)/configmap-reload
 DOCKER_IMAGE_NAME ?= jimmidyson/configmap-reload
 DOCKER_IMAGE_TAG ?= latest
 
-LDFLAGS := -s -w -extldflags '-static'
+LDFLAGS := -s -w
 
 SRCFILES := $(shell find . ! -path './out/*' ! -path './.git/*' -type f)
 


### PR DESCRIPTION
Remediates CVE-2023-3089 by setting `CGO_ENABLED=1` and removing the `extldflags -static`.